### PR TITLE
set gitconfig core.autocrlf to input rather than true

### DIFF
--- a/00_Getting_Started
+++ b/00_Getting_Started
@@ -76,9 +76,10 @@ repository.  Some of the features include:
   which lives at ~/.gitconfig)
 
   o To avoid problems with DOS EOL sequences, we always store in the
-    repository using UNIX EOL sequences.   Turn on autocrlf to avoid problems.
+    repository using UNIX EOL sequences.   Set autocrlf to input to
+    avoid these problems.
 
-    $ git config --global core.autocrlf true
+    $ git config --global core.autocrlf input
 
   o It is handy to set up local copies of remote branches automatically.
 


### PR DESCRIPTION
when core.autocrlf is true it trys to preserve the original EOL
setting while making the file outside conform to UNIX EOL.   We
want to force all EOL to UNIX EOL.   autocrlf input will do that.

Note setting to true would also be reasonable.
