### PR TITLE
x2xxx: fixed getStopBit() and getTransmitReceiveMode() redefinition typo...

### DIFF
--- a/tos/chips/msp430/x2xxx/usci/HplMsp430UsciB.nc
+++ b/tos/chips/msp430/x2xxx/usci/HplMsp430UsciB.nc
@@ -185,10 +185,6 @@ interface HplMsp430UsciB {
   async command void setTransmitMode();
   async command void setReceiveMode();
 
-  /* get bits of uctl1 in i2c mode */
-  async command bool getStopBit();
-  async command bool getTransmitReceiveMode();
-
   /* h/w bits for controlling what to send next when master */
   async command void setTXNACK();
   async command void setTXStop();

--- a/tos/chips/msp430/x2xxx/usci/HplMsp430UsciB1P.nc
+++ b/tos/chips/msp430/x2xxx/usci/HplMsp430UsciB1P.nc
@@ -142,7 +142,7 @@ implementation {
   /*
    * Reset/unReset
    *
-   * resetUsci(bool): (deprecated) TRUE puts device into reset, FALSE takes it out.  But this
+   * resetUsci(bool): (DEPRECATED) TRUE puts device into reset, FALSE takes it out.  But this
    *   requires pushing the parameter on the stack and all those extra instructions.
    *
    * {un,}resetUsci_n(): reset and unreset the device but result in single instruction that
@@ -402,10 +402,6 @@ implementation {
   async command void Usci.setTransmitMode() { UCB1CTL1 |=  UCTR; }
   async command void Usci.setReceiveMode()  { UCB1CTL1 &= ~UCTR; }
 
-  /* get stop bit in i2c mode */
-  async command bool Usci.getStopBit() { return (UCB1CTL1 & UCTXSTP); }
-  async command bool Usci.getTransmitReceiveMode() { return (UCB1CTL1 & UCTR); }
-
   /* transmit a NACK, Stop condition, or Start condition, automatically cleared */
   async command void Usci.setTXNACK()  { UCB1CTL1 |= UCTXNACK; }
   async command void Usci.setTXStop()  { UCB1CTL1 |= UCTXSTP;  }
@@ -413,6 +409,7 @@ implementation {
 
   /*
    * get/set I2COA, Own Address register
+   * clears UCGCEN, Genernal Call response enable
    */
   async command uint16_t Usci.getOwnAddress() {
     return (UCB1I2COA & ~UCGCEN);


### PR DESCRIPTION
I migrated my development from msp430-int branch to tp-master and found out that probably merging from tinyos-main has broken x2xx Usci.

Here is my manual merge that I did some time ago: https://github.com/andresv/prod/commit/42fa931b8abcf772cedd3648d114b1c0d04b160d
