### PR TITLE
ADC12 register names.

### DIFF
--- a/tos/chips/msp430/adc12/HplAdc12P.nc
+++ b/tos/chips/msp430/adc12/HplAdc12P.nc
@@ -52,7 +52,7 @@
 #endif
 
 #if defined(__MSP430_HAS_ADC12_PLUS__)
-#warning "HplAdc12P: processor uses ADC12_PLUS (may need review)"
+#warning "HplAdc12P: processor uses ADC12_PLUS (may not work correctly)"
 #endif
 
 module HplAdc12P {
@@ -117,20 +117,20 @@ implementation
      * for now leave the trunk version.
      */
     ADC12CTL0 |= ADC12ON;
-    ADC12CTL0 |= (ADC12SC | ADC12ENC);
+    ADC12CTL0 |= (ADC12SC | ENC);
   }
 
   async command void HplAdc12.stopConversion(){
     // stop conversion mode immediately, conversion data is unreliable
     uint16_t ctl1 = ADC12CTL1;
-    ADC12CTL1 &= ~(ADC12CONSEQ0 | ADC12CONSEQ1);
-    ADC12CTL0 &= ~(ADC12SC + ADC12ENC); 
+    ADC12CTL1 &= ~(CONSEQ0 | CONSEQ1);
+    ADC12CTL0 &= ~(ADC12SC + ENC); 
     ADC12CTL0 &= ~(ADC12ON);
-    ADC12CTL1 |= (ctl1 & (ADC12CONSEQ0 | ADC12CONSEQ1));
+    ADC12CTL1 |= (ctl1 & (CONSEQ0 | CONSEQ1));
   }
 
   async command void HplAdc12.enableConversion(){ 
-    ADC12CTL0 |= ADC12ENC; 
+    ADC12CTL0 |= ENC; 
   }
 
   async command bool HplAdc12.isBusy(){ return (ADC12CTL1 & ADC12BUSY); }


### PR DESCRIPTION
msp430hardware.h defines the appropriate register names (ENC, CONSEQx),
but HplAdc12P doesn't use them. The versions without the ADC12 prefix
are not defined on the x2xx.
